### PR TITLE
Hotfix/create item from add button in top bar

### DIFF
--- a/Builder/MenuBuilder.php
+++ b/Builder/MenuBuilder.php
@@ -24,7 +24,7 @@ class MenuBuilder
     /**
      * MenuBuilder constructor.
      *
-     * @param EntityManager $entityManager
+     * @param EntityManager    $entityManager
      * @param FactoryInterface $factory
      */
     public function __construct(MenuManipulator $menuManipulator, RequestStack $requestStack, EntityManager $entityManager, FactoryInterface $factory)
@@ -130,7 +130,7 @@ class MenuBuilder
      * Create KnpMenuItem.
      *
      * @param string $machineName The name of menu
-     * @param string $locale Language code (Recommanded ISO-639)
+     * @param string $locale      Language code (Recommanded ISO-639)
      *
      * @return KnpMenuItem Get formatted menu
      */
@@ -140,7 +140,7 @@ class MenuBuilder
             throw new UnexpectedValueException('The parameter $machineName must be a non empty string');
         }
 
-        if($locale === null && $this->request !== null) {
+        if ($locale === null && $this->request !== null) {
             $locale = $this->request->getLocale();
         }
 
@@ -170,15 +170,15 @@ class MenuBuilder
     /**
      * Create tree un KnpMenuItem.
      *
-     * @param KnpMenuItem $knpMenu
-     * @param ItemInterface $item
+     * @param KnpMenuItem      $knpMenu
+     * @param ItemInterface    $item
      * @param KnpMenuItem|null $parent
      *
      * @return KnpMenuItem A formatted KnpMenu
      */
     protected function getTree(KnpMenuItem $knpMenu, ItemInterface $item, KnpMenuItem $parent = null)
     {
-        if($parent === null) {
+        if ($parent === null) {
             $menuItem = $knpMenu->addChild($item);
         } else {
             $menuItem = $parent->addChild($item);
@@ -186,10 +186,10 @@ class MenuBuilder
 
         if (($uri = $item->getUri()) !== null) {
             if ($uri[0] == '/') {
-                $baseUri = $this->request->getBasePath() .
-                    $this->request->getBaseURL() .
+                $baseUri = $this->request->getBasePath().
+                    $this->request->getBaseURL().
                     $uri;
-                $uri = $this->request->getSchemeAndHttpHost() . $baseUri;
+                $uri = $this->request->getSchemeAndHttpHost().$baseUri;
 
                 if ($baseUri === $this->currentUri) {
                     $menuItem->setCurrent(true);
@@ -200,7 +200,7 @@ class MenuBuilder
 
         $menuItem->setAttributes([
             'position' => $item->getPosition(),
-            'slug' => $item->getSlug(),
+            'slug'     => $item->getSlug(),
         ]);
 
         foreach ($item->getChildren() as $child) {

--- a/Controller/Admin/CRUD/ItemAdmin.php
+++ b/Controller/Admin/CRUD/ItemAdmin.php
@@ -79,14 +79,14 @@ class ItemAdmin extends Admin
     protected function configureFormFields(FormMapper $formMapper)
     {
         $subject = $this->getSubject();
-        $isNew   = ($this->id($subject) === null) ? true : false;
+        $isNew = ($this->id($subject) === null) ? true : false;
 
         if ($isNew === true) {
             $idMenu = $this->getRequest()->query->getInt('create-menu');
             $idItem = $this->getRequest()->query->getInt('create-item');
         } else {
-            $idMenu  = $subject->getMenu()->getId();
-            $idItem  = ($subject->getParent() !== null) ? $subject->getParent()->getId() : 0;
+            $idMenu = $subject->getMenu()->getId();
+            $idItem = ($subject->getParent() !== null) ? $subject->getParent()->getId() : 0;
         }
 
         $formMapper
@@ -108,9 +108,9 @@ class ItemAdmin extends Admin
 
         if ($idItem === 0 && $idMenu === 0 || $isNew === false && $subject->getParent() !== null || $isNew === true && $idItem > 0) {
             $formMapper->add('parent', null, [
-                'label'    => 'Item parent',
-                'required' => true,
-                'property' => 'name',
+                'label'         => 'Item parent',
+                'required'      => true,
+                'property'      => 'name',
                 'query_builder' => function (EntityRepository $entityRepository) use ($idItem) {
                     $query = $entityRepository->createQuerybuilder('i');
                     if ($idItem === 0) {
@@ -120,7 +120,7 @@ class ItemAdmin extends Admin
                     return $query
                         ->where('i.id = :id')
                         ->setParameter('id', $idItem);
-                }
+                },
             ]);
         }
 

--- a/Controller/Admin/CRUD/ItemAdmin.php
+++ b/Controller/Admin/CRUD/ItemAdmin.php
@@ -53,7 +53,14 @@ class ItemAdmin extends Admin
         $query = parent::createQuery($context);
         if ($this->getRequest() instanceof Request) {
             $requestQuery = $this->getRequest()->query;
-            if ($requestQuery->has('menu')) {
+            if ($requestQuery->has('item')) {
+                $parentId = $requestQuery->getInt('item');
+                $query->join($query->getRootAlias().'.parent', 'p')
+                    ->andWhere('p.id = :parentId')
+                    ->setParameters([
+                        'parentId' => $parentId,
+                    ]);
+            } elseif ($requestQuery->has('menu')) {
                 $menuId = $requestQuery->getInt('menu');
                 $query
                     ->join($query->getRootAlias().'.menu', 'm')
@@ -62,15 +69,6 @@ class ItemAdmin extends Admin
                     ->andwhere('p.id IS NULL')
                     ->setParameters([
                         'menuId' => $menuId,
-                    ]);
-            }
-
-            if ($requestQuery->has('item')) {
-                $parentId = $requestQuery->getInt('item');
-                $query->join($query->getRootAlias().'.parent', 'p')
-                    ->andWhere('p.id = :parentId')
-                    ->setParameters([
-                        'parentId' => $parentId,
                     ]);
             }
         }

--- a/Controller/Admin/CRUD/ItemAdmin.php
+++ b/Controller/Admin/CRUD/ItemAdmin.php
@@ -155,9 +155,6 @@ class ItemAdmin extends Admin
             ->add('_action', 'actions', [
                 'actions' => [
                     'edit' => [],
-                    'add'  => [
-                        'template' => 'AlpixelMenuBundle:CRUD:add__action_item.html.twig',
-                    ],
                     'move' => [
                         'template' => 'PixSortableBehaviorBundle:Default:_sort.html.twig',
                     ],

--- a/Controller/Admin/CRUD/MenuAdmin.php
+++ b/Controller/Admin/CRUD/MenuAdmin.php
@@ -20,6 +20,7 @@ class MenuAdmin extends Admin
     protected function configureRoutes(RouteCollection $collection)
     {
         $collection->remove('create');
+        $collection->remove('delete');
         $collection->add('item', $this->getRouterIdParameter().'/item');
     }
 

--- a/Controller/Admin/CRUD/MenuAdmin.php
+++ b/Controller/Admin/CRUD/MenuAdmin.php
@@ -69,9 +69,6 @@ class MenuAdmin extends Admin
                     'item' => [
                         'template' => 'AlpixelMenuBundle:CRUD:list__action_item.html.twig',
                     ],
-                    'add' => [
-                        'template' => 'AlpixelMenuBundle:CRUD:add__action_item.html.twig',
-                    ],
                 ],
             ]);
     }

--- a/Controller/CRUDController.php
+++ b/Controller/CRUDController.php
@@ -19,10 +19,73 @@ class CRUDController extends Controller
         if ($object instanceof Menu) {
             $parameters['menu'] = $object->getId();
         } elseif ($object instanceof Item) {
+            $parameters['menu'] = $object->getMenu()->getId();
             $parameters['item'] = $object->getId();
         }
 
         $url = $router->generate('admin_alpixel_menu_item_list', $parameters, UrlGeneratorInterface::ABSOLUTE_PATH);
+
+        return new RedirectResponse($url);
+    }
+
+    protected function redirectTo($object)
+    {
+        $request = $this->getRequest();
+
+        $url = false;
+        $params = [];
+
+        if ($object instanceof Item) {
+            if ($object->getParent() !== null) {
+                $itemId = $object->getParent()->getId();
+                $params['list']['item'] = $itemId;
+                $params['create']['create-item'] = $itemId;
+            }
+            $menuId = $object->getMenu()->getId();
+            $params['list']['menu'] = $menuId;
+            $params['create']['create-menu'] = $menuId;
+        } elseif ($object instanceof Menu) {
+            $menuId = $object->getId();
+            $params['list']['menu'] = $menuId;
+            $params['create']['create-menu'] = $menuId;
+        }
+
+        if (null !== $request->get('btn_update_and_list')) {
+            $url = $this->admin->generateUrl('list', $params['list']);
+        } elseif (null !== $request->get('btn_create_and_list')) {
+            $url = $this->admin->generateUrl('list', $params['list']);
+        }
+
+        if (null !== $request->get('btn_create_and_create')) {
+            if ($this->admin->hasActiveSubClass()) {
+                $params['create']['subclass'] = $request->get('subclass');
+            }
+            $url = $this->admin->generateUrl('create', $params['create']);
+        }
+
+        if ($this->getRestMethod() === 'DELETE') {
+            if ($object instanceof Item) {
+                $url = $this->admin->generateUrl('list', $params['list']);
+            }
+            else {
+                $router = $this->get('router');
+                $url= $router->generate('admin_alpixel_menu_menu_list');
+            }
+        }
+
+        if (!$url) {
+            foreach (array('edit', 'show') as $route) {
+                if ($this->admin->hasRoute($route) && $this->admin->isGranted(strtoupper($route), $object)) {
+                    $url = $this->admin->generateObjectUrl($route, $object);
+                    break;
+                }
+            }
+        }
+
+        if (!$url) {
+            $router = $this->get('router');
+            $url= $router->generate('admin_alpixel_menu_menu_list');
+        }
 
         return new RedirectResponse($url);
     }

--- a/Controller/CRUDController.php
+++ b/Controller/CRUDController.php
@@ -66,15 +66,14 @@ class CRUDController extends Controller
         if ($this->getRestMethod() === 'DELETE') {
             if ($object instanceof Item) {
                 $url = $this->admin->generateUrl('list', $params['list']);
-            }
-            else {
+            } else {
                 $router = $this->get('router');
-                $url= $router->generate('admin_alpixel_menu_menu_list');
+                $url = $router->generate('admin_alpixel_menu_menu_list');
             }
         }
 
         if (!$url) {
-            foreach (array('edit', 'show') as $route) {
+            foreach (['edit', 'show'] as $route) {
                 if ($this->admin->hasRoute($route) && $this->admin->isGranted(strtoupper($route), $object)) {
                     $url = $this->admin->generateObjectUrl($route, $object);
                     break;
@@ -84,7 +83,7 @@ class CRUDController extends Controller
 
         if (!$url) {
             $router = $this->get('router');
-            $url= $router->generate('admin_alpixel_menu_menu_list');
+            $url = $router->generate('admin_alpixel_menu_menu_list');
         }
 
         return new RedirectResponse($url);

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -27,6 +27,7 @@ services:
             - AlpixelMenuBundle:CRUD
         calls:
             - [ setTemplate, [edit, AlpixelMenuBundle:CRUD:edit__item.html.twig]]
+            - [ setTemplate, [list, AlpixelMenuBundle:CRUD:list_item.html.twig]]
             - [ setPositionService, ["@pix_sortable_behavior.position"]]
 
     gedmo.listener.sortable:

--- a/Resources/views/CRUD/action_buttons_item.html.twig
+++ b/Resources/views/CRUD/action_buttons_item.html.twig
@@ -1,18 +1,9 @@
-{% set url = '' %}
-{% if app.request.query.has('menu') and app.request.query.has('item') %}
-    {% set url = path('admin_alpixel_menu_item_create', {
-        'create-menu' : app.request.query.get('menu'),
-        'create-item': app.request.query.get('item')})
-    %}
-{% elseif app.request.query.has('menu') %}
-    {% set url = path('admin_alpixel_menu_item_create', {
-        'create-menu' : app.request.query.get('menu')})
-    %}
-{% endif %}
-{% if url is not empty %}
+{% import 'AlpixelMenuBundle:CRUD:macro_add_item_link.html.twig' as item %}
+
+{% if item.add_link() is not empty %}
     <ul class="nav navbar-nav navbar-right">
         <li>
-            <a class="sonata-action-element" href="{{ url }}"><i class="fa fa-plus-circle"></i>Ajouter</a>
+            <a class="sonata-action-element" href="{{ item.add_link() }}"><i class="fa fa-plus-circle"></i>Ajouter</a>
         </li>
     </ul>
 {% endif %}

--- a/Resources/views/CRUD/action_buttons_item.html.twig
+++ b/Resources/views/CRUD/action_buttons_item.html.twig
@@ -1,0 +1,18 @@
+{% set url = '' %}
+{% if app.request.query.has('menu') and app.request.query.has('item') %}
+    {% set url = path('admin_alpixel_menu_item_create', {
+        'create-menu' : app.request.query.get('menu'),
+        'create-item': app.request.query.get('item')})
+    %}
+{% elseif app.request.query.has('menu') %}
+    {% set url = path('admin_alpixel_menu_item_create', {
+        'create-menu' : app.request.query.get('menu')})
+    %}
+{% endif %}
+{% if url is not empty %}
+    <ul class="nav navbar-nav navbar-right">
+        <li>
+            <a class="sonata-action-element" href="{{ url }}"><i class="fa fa-plus-circle"></i>Ajouter</a>
+        </li>
+    </ul>
+{% endif %}

--- a/Resources/views/CRUD/add__action_item.html.twig
+++ b/Resources/views/CRUD/add__action_item.html.twig
@@ -1,5 +1,0 @@
-{% if object.children is defined  %}
-    <a class="btn btn-default btn-sm" href="{{ path('admin_alpixel_menu_item_create', {'create-menu' : object.menu.id, 'create-item': object.id}) }}"><i class="fa fa-plus"></i> Ajouter un élément</a>
-{% elseif object.items is defined %}
-    <a class="btn btn-default btn-sm" href="{{ path('admin_alpixel_menu_item_create', {'create-menu' : object.id}) }}"><i class="fa fa-plus"></i> Ajouter un élément</a>
-{% endif %}

--- a/Resources/views/CRUD/edit__item.html.twig
+++ b/Resources/views/CRUD/edit__item.html.twig
@@ -2,7 +2,6 @@
 
 {% form_theme form.uri 'AlpixelMenuBundle:Form:item_uri.html.twig' %}
 
-
 {% block javascripts %}
     {{ parent() }}
     <script src="{{ asset('bundles/alpixelmenu/js/item_uri_input.js') }}" type="text/javascript"></script>

--- a/Resources/views/CRUD/edit__item.html.twig
+++ b/Resources/views/CRUD/edit__item.html.twig
@@ -2,6 +2,7 @@
 
 {% form_theme form.uri 'AlpixelMenuBundle:Form:item_uri.html.twig' %}
 
+
 {% block javascripts %}
     {{ parent() }}
     <script src="{{ asset('bundles/alpixelmenu/js/item_uri_input.js') }}" type="text/javascript"></script>

--- a/Resources/views/CRUD/list__action_item.html.twig
+++ b/Resources/views/CRUD/list__action_item.html.twig
@@ -1,4 +1,4 @@
-{% if object.children is defined and object.children|length == 0 or object.items is defined and object.items|length == 0 %}
+{% if object.children is defined and object.children|length == 0 %}
     <span class="btn btn-default btn-sm">Cet élément n'a aucun sous-menu</span>
 {% else %}
     <a class="btn btn-primary btn-sm" href="{{ admin.generateObjectUrl('item', object) }}">Gérér les sous-menu</a>

--- a/Resources/views/CRUD/list_item.html.twig
+++ b/Resources/views/CRUD/list_item.html.twig
@@ -1,0 +1,5 @@
+{% extends 'SonataAdminBundle:CRUD:list.html.twig' %}
+
+{% block actions %}
+    {% include 'AlpixelMenuBundle:CRUD:action_buttons_item.html.twig' %}
+{% endblock %}

--- a/Resources/views/CRUD/list_item.html.twig
+++ b/Resources/views/CRUD/list_item.html.twig
@@ -1,5 +1,187 @@
+{% import 'AlpixelMenuBundle:CRUD:macro_add_item_link.html.twig' as item %}
+
 {% extends 'SonataAdminBundle:CRUD:list.html.twig' %}
 
 {% block actions %}
     {% include 'AlpixelMenuBundle:CRUD:action_buttons_item.html.twig' %}
+{% endblock %}
+
+{% block list_table %}
+    <div class="col-xs-12 col-md-12">
+        {% set batchactions = admin.batchactions %}
+        {% if admin.hasRoute('batch') and batchactions|length %}
+        <form action="{{ admin.generateUrl('batch', {'filter': admin.filterParameters}) }}" method="POST" >
+            <input type="hidden" name="_sonata_csrf_token" value="{{ csrf_token }}">
+            {% endif %}
+
+            {# Add a margin if no pager to prevent dropdown cropping on window #}
+            <div class="box box-primary" {% if admin.datagrid.pager.lastPage == 1 %}style="margin-bottom: 100px;"{% endif %}>
+                <div class="box-body {% if admin.datagrid.results|length > 0 %}table-responsive no-padding{% endif %}">
+                    {{ sonata_block_render_event('sonata.admin.list.table.top', { 'admin': admin }) }}
+
+                    {% block list_header %}{% endblock %}
+
+                    {% if admin.datagrid.results|length > 0 %}
+                        <table class="table table-bordered table-striped sonata-ba-list">
+                            {% block table_header %}
+                                <thead>
+                                <tr class="sonata-ba-list-field-header">
+                                    {% for field_description in admin.list.elements %}
+                                        {% if admin.hasRoute('batch') and field_description.getOption('code') == '_batch' and batchactions|length > 0 %}
+                                            <th class="sonata-ba-list-field-header sonata-ba-list-field-header-batch">
+                                                <input type="checkbox" id="list_batch_checkbox">
+                                            </th>
+                                        {% elseif field_description.getOption('code') == '_select' %}
+                                            <th class="sonata-ba-list-field-header sonata-ba-list-field-header-select"></th>
+                                        {% elseif field_description.name == '_action' and app.request.isXmlHttpRequest %}
+                                            {# Action buttons disabled in ajax view! #}
+                                        {% elseif field_description.getOption('ajax_hidden') == true and app.request.isXmlHttpRequest %}
+                                            {# Disable fields with 'ajax_hidden' option set to true #}
+                                        {% else %}
+                                            {% set sortable = false %}
+                                            {% if field_description.options.sortable is defined and field_description.options.sortable %}
+                                                {% set sortable             = true %}
+                                                {% set sort_parameters      = admin.modelmanager.sortparameters(field_description, admin.datagrid) %}
+                                                {% set current              = admin.datagrid.values._sort_by == field_description or admin.datagrid.values._sort_by.fieldName == sort_parameters.filter._sort_by %}
+                                                {% set sort_active_class    = current ? 'sonata-ba-list-field-order-active' : '' %}
+                                                {% set sort_by              = current ? admin.datagrid.values._sort_order : field_description.options._sort_order %}
+                                            {% endif %}
+
+                                            {% spaceless %}
+                                                <th class="sonata-ba-list-field-header-{{ field_description.type}} {% if sortable %} sonata-ba-list-field-header-order-{{ sort_by|lower }} {{ sort_active_class }}{% endif %}{% if field_description.options.header_class is defined %} {{ field_description.options.header_class }}{% endif %}"{% if field_description.options.header_style is defined %} style="{{ field_description.options.header_style }}"{% endif %}>
+                                                    {% if sortable %}<a href="{{ admin.generateUrl('list', sort_parameters) }}">{% endif %}
+                                                        {{ admin.trans(field_description.label, {}, field_description.translationDomain) }}
+                                                        {% if sortable %}</a>{% endif %}
+                                                </th>
+                                            {% endspaceless %}
+                                        {% endif %}
+                                    {% endfor %}
+                                </tr>
+                                </thead>
+                            {% endblock %}
+
+                            {% block table_body %}
+                                <tbody>
+                                {% include admin.getTemplate('outer_list_rows_' ~ admin.getListMode()) %}
+                                </tbody>
+                            {% endblock %}
+
+                            {% block table_footer %}
+                            {% endblock %}
+                        </table>
+                    {% else %}
+                        <div class="info-box">
+                            <span class="info-box-icon bg-aqua"><i class="fa fa-arrow-circle-right"></i></span>
+                            <div class="info-box-content">
+                                <span class="info-box-text">{{ 'no_result'|trans({}, 'SonataAdminBundle') }}</span>
+                                <div class="progress">
+                                    <div class="progress-bar" style="width: 0%"></div>
+                                </div>
+                            <span class="progress-description">
+                                {% if not app.request.xmlHttpRequest %}
+                                    <a class="sonata-action-element" href="{{ item.add_link() }}"><i class="fa fa-plus-circle"></i>Ajouter</a>
+                                {% endif %}
+                            </span>
+                            </div><!-- /.info-box-content -->
+                        </div>
+                    {% endif %}
+
+                    {{ sonata_block_render_event('sonata.admin.list.table.bottom', { 'admin': admin }) }}
+                </div>
+                {% block list_footer %}
+                    {% if admin.datagrid.results|length > 0 %}
+                        <div class="box-footer">
+                            <div class="form-inline clearfix">
+                                {% if not app.request.isXmlHttpRequest %}
+                                    <div class="pull-left">
+                                        {% if admin.hasRoute('batch') and batchactions|length > 0  %}
+                                            {% block batch %}
+                                                <script>
+                                                    {% block batch_javascript %}
+                                                    jQuery(document).ready(function ($) {
+                                                        $('#list_batch_checkbox').on('ifChanged', function () {
+                                                            $(this)
+                                                                    .closest('table')
+                                                                    .find('td.sonata-ba-list-field-batch input[type="checkbox"], div.sonata-ba-list-field-batch input[type="checkbox"]')
+                                                                    .iCheck($(this).is(':checked') ? 'check' : 'uncheck')
+                                                            ;
+                                                        });
+
+                                                        $('td.sonata-ba-list-field-batch input[type="checkbox"], div.sonata-ba-list-field-batch input[type="checkbox"]')
+                                                                .on('ifChanged', function () {
+                                                                    $(this)
+                                                                            .closest('tr, div.sonata-ba-list-field-batch')
+                                                                            .toggleClass('sonata-ba-list-row-selected', $(this).is(':checked'))
+                                                                    ;
+                                                                })
+                                                                .trigger('ifChanged')
+                                                        ;
+                                                    });
+                                                    {% endblock %}
+                                                </script>
+
+                                            {% block batch_actions %}
+                                                <label class="checkbox" for="{{ admin.uniqid }}_all_elements">
+                                                    <input type="checkbox" name="all_elements" id="{{ admin.uniqid }}_all_elements">
+                                                    {{ 'all_elements'|trans({}, 'SonataAdminBundle') }}
+                                                    ({{ admin.datagrid.pager.nbresults }})
+                                                </label>
+
+                                                <select name="action" style="width: auto; height: auto" class="form-control">
+                                                    {% for action, options in batchactions %}
+                                                        <option value="{{ action }}">{{ options.label|trans({}, options.translation_domain|default(admin.translationDomain)) }}</option>
+                                                    {% endfor %}
+                                                </select>
+                                            {% endblock %}
+
+                                                <input type="submit" class="btn btn-small btn-primary" value="{{ 'btn_batch'|trans({}, 'SonataAdminBundle') }}">
+                                            {% endblock %}
+                                        {% endif %}
+                                    </div>
+
+
+                                    <div class="pull-right">
+                                        {% if admin.hasRoute('export') and admin.isGranted('EXPORT') and admin.getExportFormats()|length %}
+                                            <div class="btn-group">
+                                                <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown">
+                                                    <i class="fa fa-share-square-o"></i>
+                                                    {{ "label_export_download"|trans({}, "SonataAdminBundle") }}
+                                                    <span class="caret"></span>
+                                                </button>
+                                                <ul class="dropdown-menu">
+                                                    {% for format in admin.getExportFormats() %}
+                                                    <li>
+                                                        <a href="{{ admin.generateUrl('export', admin.modelmanager.paginationparameters(admin.datagrid, 0) + {'format' : format}) }}">
+                                                            <i class="fa fa-arrow-circle-o-down"></i>
+                                                            {{ ("export_format_" ~ format)|trans({}, 'SonataAdminBundle') }}
+                                                        </a>
+                                                    <li>
+                                                        {% endfor %}
+                                                </ul>
+                                            </div>
+
+                                            &nbsp;-&nbsp;
+                                        {% endif %}
+
+                                        {% block pager_results %}
+                                            {% include admin.getTemplate('pager_results') %}
+                                        {% endblock %}
+                                    </div>
+                                {% endif %}
+                            </div>
+
+                            {% block pager_links %}
+                                {% if admin.datagrid.pager.haveToPaginate() %}
+                                    <hr/>
+                                    {% include admin.getTemplate('pager_links') %}
+                                {% endif %}
+                            {% endblock %}
+                        </div>
+                    {% endif %}
+                {% endblock %}
+            </div>
+            {% if admin.hasRoute('batch') and batchactions|length %}
+        </form>
+        {% endif %}
+    </div>
 {% endblock %}

--- a/Resources/views/CRUD/macro_add_item_link.html.twig
+++ b/Resources/views/CRUD/macro_add_item_link.html.twig
@@ -1,0 +1,12 @@
+{% macro add_link() %}
+    {% spaceless %}
+        {% if app.request.query.has('menu') and app.request.query.has('item') %}
+            {{ path('admin_alpixel_menu_item_create', {
+                'create-menu' : app.request.query.get('menu'),
+                'create-item': app.request.query.get('item')}) }}
+        {% elseif app.request.query.has('menu') %}
+            {{ path('admin_alpixel_menu_item_create', {
+                'create-menu' : app.request.query.get('menu')}) }}
+        {% endif %}
+    {% endspaceless %}
+{% endmacro %}


### PR DESCRIPTION
- Use add action on top navigation instead custom add action.
- Redirect to the correct tree path.
- Override add action when list template is empty.
- Create macro for add action link item
